### PR TITLE
Implements DER (un)wrapping using the existing helpers

### DIFF
--- a/packages/identity/src/identity/der.ts
+++ b/packages/identity/src/identity/der.ts
@@ -55,6 +55,16 @@ const decodeLenBytes = (buf: Uint8Array, offset: number): number => {
   throw new Error('Length too long (> 4 bytes)');
 };
 
+const decodeLen = (buf: Uint8Array, offset: number): number => {
+  const lenBytes = decodeLenBytes(buf, offset);
+  if (lenBytes === 1) return buf[offset];
+  else if (lenBytes === 2) return buf[offset + 1];
+  else if (lenBytes === 3) return buf[offset + 1] << (8 + buf[offset + 2]);
+  else if (lenBytes === 4)
+    return (buf[offset + 1] << (16 + buf[offset + 2])) << (8 + buf[offset + 3]);
+  throw new Error('Length too long (> 4 bytes)');
+};
+
 /**
  * A DER encoded `SEQUENCE(OID)` for DER-encoded-COSE
  */
@@ -74,32 +84,14 @@ export const ED25519_OID = Uint8Array.from([
 ]);
 
 /**
- * PLACEHOLDER - DO NOT MERGE THIS
+ * A DER encoded `SEQUENCE(OID)` for secp256k1 with the ECDSA algorithm
  */
 export const SECP256K1_OID = Uint8Array.from([
-  0x30,
-  0x56, // SEQUENCE
-  0x30,
-  0x10, // SEQUENCE
-  0x06,
-  0x07,
-  0x2a,
-  0x86,
-  0x48,
-  0xce,
-  0x3d,
-  0x02,
-  0x01, // OID ECDSA
-  0x06,
-  0x05,
-  0x2b,
-  0x81,
-  0x04,
-  0x00,
-  0x0a, // OID secp256k1
-  0x03,
-  0x42, // BIT STRING
-  0x00, // no padding
+  ...[0x30, 0x10], // SEQUENCE
+  ...[0x06, 0x07], // OID with 7 bytes
+  ...[0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01], // OID ECDSA
+  ...[0x06, 0x05], // OID with 5 bytes
+  ...[0x2b, 0x81, 0x04, 0x00, 0x0a], // OID secp256k1
 ]);
 
 /**
@@ -161,7 +153,14 @@ export const unwrapDER = (derEncoded: ArrayBuffer, oid: Uint8Array): Uint8Array 
   offset += oid.byteLength;
 
   expect(0x03, 'bit string');
+  const payloadLen = decodeLen(buf, offset) - 1; // Subtracting 1 to account for the 0 padding
   offset += decodeLenBytes(buf, offset);
   expect(0x00, '0 padding');
-  return buf.slice(offset);
+  const result = buf.slice(offset);
+  if (payloadLen !== result.length) {
+    throw new Error(
+      `DER payload mismatch: Expected length ${payloadLen} actual length ${result.length}`,
+    );
+  }
+  return result;
 };


### PR DESCRIPTION
I had to add an additional check to the existing logic to fail the given test vector with a correct header and payload but some extra bytes.